### PR TITLE
Fix collision with stock R Visuals

### DIFF
--- a/templates/visuals/rvisual/capabilities.json
+++ b/templates/visuals/rvisual/capabilities.json
@@ -25,11 +25,11 @@
           "scriptProviderDefault": "R",
           "scriptOutputType": "png",
           "source": {
-            "objectName": "script",
+            "objectName": "rcv_script",
             "propertyName": "source"
           },
           "provider": {
-            "objectName": "script",
+            "objectName": "rcv_script",
             "propertyName": "provider"
           }
         }
@@ -37,7 +37,7 @@
     }
   ],
   "objects": {
-    "script": {
+    "rcv_script": {
       "properties": {
         "provider": {
           "type": { "text": true }


### PR DESCRIPTION
The custom R Visuals will save their script and provider to a separate object (rcv_script) which is not being used by the stock R visuals.
This way when a user converts a stock R visual to a custom R visual, the custom R visual will not use the script from the stock R visual.