### PR TITLE
Update VisualBuilder to Allow External Bundling

### DIFF
--- a/lib/TypescriptCompiler.js
+++ b/lib/TypescriptCompiler.js
@@ -165,16 +165,16 @@ function copyPackageFilesWithNamespace(visualPackage, files) {
     return files.map(file => {
         let filePath = visualPackage.buildPath(file);
         let targetPath = visualPackage.buildPath(config.build.precompileFolder, file);
-        let normailzedFileName = path.basename(filePath).toLowerCase().trim();
+        let normalizedFileName = path.basename(filePath).toLowerCase().trim();
 
-        if (normailzedFileName.slice(-5) === '.d.ts') {
+        if (normalizedFileName.slice(-5) === '.d.ts') {
             //d.ts file - fix file path
             return filePath;
         }
 
         fs.ensureDirSync(path.dirname(targetPath));
 
-        if (normailzedFileName.slice(-3) === '.ts') {
+        if (normalizedFileName.slice(-3) === '.ts') {
             //ts file - add namespace and copy
             copyFileWithNamespace(filePath, targetPath, guid);
             return targetPath;

--- a/lib/VisualBuilder.js
+++ b/lib/VisualBuilder.js
@@ -87,17 +87,24 @@ class VisualBuilder extends EventEmitter {
      * Compiles visual sources & styles
      */
     build() {
-
         return this._validateApiVersion(this.visualPackage)
-            .then(() => LessCompiler.build(this.visualPackage, this.buildOptions))
-            .then(() => TypescriptCompiler.build(this.visualPackage, this.buildOptions))
+            .then(() => {
+                if (!this._isBundledExternally('css')) {
+                    return LessCompiler.build(this.visualPackage, this.buildOptions);
+                }
+            })
+            .then(() => {
+                if (!this._isBundledExternally('js')) {
+                    return TypescriptCompiler.build(this.visualPackage, this.buildOptions);
+                }
+            })
             .then(() => this._createPbivizJson())
             .then(() => this._updateStatus());
     }
 
     /**
      * Starts watching for file changes
-     * 
+     *
      * @returns {Promise}
      */
     startWatcher() {
@@ -186,8 +193,13 @@ class VisualBuilder extends EventEmitter {
             let iconContent = getBase64Icon(this.visualPackage.buildPath(visualConfig.assets.icon));
             if (!iconContent) return reject(new Error('Invalid Icon. Must be 20x20 png.'));
             let dropPath = this.visualPackage.buildPath(config.build.dropFolder);
-            let jsContent = fs.readFileSync(path.join(dropPath, 'visual.prod.js')).toString();
-            let cssContent = fs.readFileSync(path.join(dropPath, 'visual.prod.css')).toString();
+
+            const DEFAULT_JS_BUNDLE = path.join(dropPath, 'visual.prod.js');
+            const DEFAULT_CSS_BUNDLE = path.join(dropPath, 'visual.prod.css');
+            const jsBundle = this._bundlePath('js') || DEFAULT_JS_BUNDLE;
+            const cssBundle = this._bundlePath('css') || DEFAULT_CSS_BUNDLE;
+            let jsContent = fs.readFileSync(jsBundle).toString();
+            let cssContent = fs.readFileSync(cssBundle).toString();
 
             //load and validate capabilities
             let capabilities = fs.readJsonSync(this.visualPackage.buildPath(visualConfig.capabilities));
@@ -327,41 +339,57 @@ class VisualBuilder extends EventEmitter {
     /**
      * Sets watch states to default values
      * 
+     *
      * @private
      */
     _resetWatchStates() {
+        const DO_NOTHING = () => new Promise((resolve) => resolve());
+        const tsCompiler = this._isBundledExternally('js') ? DO_NOTHING : LessCompiler.build;
+        const lessCompiler = this._isBundledExternally('css') ? DO_NOTHING : TypescriptCompiler.build;
+
         this.watchStates = {
             '.js': {
                 changed: false,
                 building: false,
                 name: 'Javascript',
-                handler: TypescriptCompiler.build
+                handler: tsCompiler,
             },
             '.ts': {
                 changed: false,
                 building: false,
                 name: 'Typescript',
-                handler: TypescriptCompiler.build
+                handler: tsCompiler,
             },
             '.less': {
                 changed: false,
                 building: false,
                 name: 'Less',
-                handler: LessCompiler.build
+                handler: lessCompiler,
             },
             '.json': {
                 changed: false,
                 building: false,
                 name: 'JSON',
-                handler: () => new Promise((resolve) => resolve())
+                handler: DO_NOTHING,
             },
             '.r': {
                 changed: false,
                 building: false,
                 name: 'RScript',
-                handler: () => new Promise((resolve) => resolve())
+                handler: DO_NOTHING,
             }
         };
+    }
+
+    _isBundledExternally(extension) {
+        return !!(this._bundlePath(extension));
+    }
+
+    _bundlePath(extension) {
+        const visualConfig = this.visualPackage.config;
+        return visualConfig.bundle &&
+            visualConfig.bundle[extension] &&
+            visualConfig.bundle[extension].path;
     }
 }
 


### PR DESCRIPTION
It is common for our use-cases to use a Javascript bundler (e.g. Webpack, Browserify, jspm) to load third-party scripts and assets. The current mechanism of an "externalJS" array leaves a lot to be wanted: it demands that developers load scripts and their dependencies in the correct order, and that those dependencies don't have a module-loading mechanism or embedded assets. It also precludes the possibility of a rich asset pipeline that performs linting, transpilation, and embeds styles and data.

This commit allows developers to specify bundle configurations in `pbiviz.json`, which allow them to sidestep the pbiviz script-building mechanism while retaining the ability to use the `pbiviz` tool for live-reloading and packaging.

Using this change, here's the configuration I'm using to perform a custom build
`pbiviz.json`
```json
{
  "visual": {
    "name": "pvtest",
    "displayName": "pvtest",
    "guid": "PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA",
    "visualClassName": "Visual",
    "version": "1.0.0",
    "description": "",
    "supportUrl": "",
    "gitHubUrl": ""
  },
  "bundle": {
    "js": {
      "path": ".tmp/drop/visual.bundle.js"
    }
  },
  "apiVersion": "1.1.0",
  "author": {
    "name": "",
    "email": ""
  },
  "assets": {
    "icon": "assets/icon.png"
  },
  "externalJS": [
  ],
  "style": "style/visual.less",
  "capabilities": "capabilities.json"
}
```

`webpack.config.js`: 

```js
const path = require('path');
const webpack = require('webpack');

module.exports = {
    entry: path.join(__dirname, '.tmp', 'build', 'transpiled', 'visual.js'),
    output: {
        path: path.join(__dirname, '.tmp', 'drop'),
        filename: 'visual.bundle.js'
    },
    module: {
        loaders: [
            { test: /\.css$/, loader: 'style!css' },
            { test: /\.(js|jsx)$/, loaders: [ 'imports?powerbi=>window["powerbi"]' ] }
        ]
    },
    plugins: [
      new webpack.optimize.OccurenceOrderPlugin(),
      new webpack.DefinePlugin({
          'process.env': {
              'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
          }
      })
    ]
};
```

`tsconfig.json`
```json
{
  "compilerOptions": {
    "allowJs": true,
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "target": "ES5",
    "sourceMap": false,
    "out": "./.tmp/build/transpiled/visual.js"
  },
  "files": [
    ".api/v1.1.0/PowerBI-visuals.d.ts",
    "typings/index.d.ts",
    "./src/visual.ts"
  ]
}

```

`package.json`
```json
{
  "name": "visual",
  "devDependencies": {
    "imports-loader": "^0.6.5",
    "onchange": "^2.5.0",
    "typescript": "^1.8.10",
    "typings": "^1.3.2",
    "webpack": "^1.13.1"
  },
  "dependencies": {
    "debug": "^2.2.0"
  },
  "scripts": {
    "tsc": "tsc",
    "webpack": "webpack",
    "watch:tsc": "npm run tsc -- -w",
    "watch:webpack": "npm run webpack -- -w",
    "watch:copy": "onchange '.tmp/drop/visual.bundle.js' -- npm run copy",
    "watch": "npm-run-all -p watch:*",
    "copy": "cp .tmp/drop/visual.bundle.js .tmp/drop/visual.js",
    "start:pbiviz": "pbiviz start",
    "start": "npm-run-all tsc webpack copy -p watch start:pbiviz"
  }
}
```

`src/visual.ts`
```
const log = require("debug")("Visual");

module powerbi.extensibility.visual.PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA.PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA  {
    log("Loading Visual");
    export class Visual implements IVisual {
        private target: HTMLElement;
        private updateCount: number;

        constructor(options: VisualConstructorOptions) {
            log("Visual constructor", options);
            this.target = options.element;
            this.updateCount = 0;
        }

        public update(options: VisualUpdateOptions) {
            log("Visual update", options);
            this.target.innerHTML = `<p>Update count: <em>${(this.updateCount++)}</em></p>`;
        }

        public destroy(): void {
            // TODO: Perform any cleanup tasks here
        }
    }

    export var PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA = {
        name: 'PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA',
        displayName: 'pvtest',
        class: 'Visual',
        version: '1.0.0',
        apiVersion: '1.1.0',
        create: (options) => new powerbi.extensibility.visual.PBI_CV_34C79648_8924_4ACD_BE2B_F90F209A8CBA.Visual(options),
        custom: true
    };
}
```
