### PR TITLE
Fix css import definitions in Less compiler

### DIFF
--- a/lib/LessCompiler.js
+++ b/lib/LessCompiler.js
@@ -51,17 +51,24 @@ class LessCompiler {
         let lessFilename = visualPackage.config.style;
         return new Promise((resolve, reject) => {
             let lessPath = visualPackage.buildPath(lessFilename);
+            let lessImportPath = path.dirname(lessPath);
             let dropCssPath = visualPackage.buildPath(config.build.dropFolder, config.build.css);
             let lessContent = fs.readFileSync(lessPath).toString();
-            lessContent = `.visual-${pluginName} { ${lessContent} }`;
+            //lessContent = `.visual-${pluginName} { ${lessContent} }`;
+            
+            let pluginNameRegExp = /@plugin-name:\s[^;]*/;
+            lessContent = lessContent.replace(pluginNameRegExp, `@plugin-name: visual-${pluginName}`);
             let lessMinifiedOptions = {
+                paths: [lessImportPath],
                 sourceMap: {
                     sourceMapURL: path.basename(dropCssPath) + '.map'
                 },
                 compress: true
             };
-
-            less.render(lessContent, options.minify ? lessMinifiedOptions : undefined).then(cssContent => {
+            let lessOptions = {
+                paths: [lessImportPath]
+            };
+            less.render(lessContent, options.minify ? lessMinifiedOptions : lessOptions).then(cssContent => {
                 fs.ensureDirSync(path.dirname(dropCssPath));
                 fs.writeFileSync(dropCssPath, cssContent.css);
                 createProdCss(dropCssPath, cssContent.css);


### PR DESCRIPTION
Adds handling for external CSS imports and provides a mechanism for user-configurable wrapping of instanced vs. global css definitions.  Wrapping everything in a brute regex'd class will break any imported files and is a very brittle approach to encapsulation.

```
@plugin-name: autoreplaceatbuildtime;

.@{plugin-name} {
    body {
        min-width: 0 !important;
    }
}

@import "http://external.link.to/custom.css";
```