### PR TITLE
16680: PBIVIZ: filter API with API 1.6.0: The method to apply a filter isn't defined in the type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./lib/VisualPackage.js",
   "scripts": {

--- a/templates/visuals/.api/v1.6.0/PowerBI-visuals.d.ts
+++ b/templates/visuals/.api/v1.6.0/PowerBI-visuals.d.ts
@@ -1183,6 +1183,7 @@ declare module powerbi.extensibility {
         hasSelection(): boolean;
         clear(): IPromise<{}>;
         getSelectionIds(): ISelectionId[];
+        applySelectionFilter(): void;
     }
 }
 


### PR DESCRIPTION
* 16680: PBIVIZ: filter API with API 1.6.0: The method to apply a filter isn't defined in the type definition
* PBIVIZ 1.6.3