### PR TITLE
17613: PBIVIZ - Power BI Desktop issue: Power BI Desktop can't import any custom visual that has been built using PBIVIZ from GitHub master

### DIFF
--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -1,9 +1,6 @@
 {
     "version": <%= JSON.stringify(visualData.version) %>,
     "author": <%= JSON.stringify(authorData) %>,
-    "devDependencies": {
-        "powerbi-visuals-utils-dataviewutils": "1.0.1"
-    },
     "resources": [
         {
             "resourceId": "rId0",


### PR DESCRIPTION
### Change log:
- 17613: PBIVIZ - Power BI Desktop issue: Power BI Desktop can't import any custom visual that has been built using PBIVIZ from GitHub master