### PR TITLE
Restore R utils

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
 
+## pbiviz v1.7.1
+* Returned removed objectEnumerationUtility.ts in R visuals template
+
 ## pbiviz v1.6.5
 * Updated npm dependencies
 * Fixed settings generation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./lib/VisualPackage.js",
   "scripts": {

--- a/templates/visuals/rhtml/src/objectEnumerationUtility.ts
+++ b/templates/visuals/rhtml/src/objectEnumerationUtility.ts
@@ -1,0 +1,27 @@
+module powerbi.extensibility.visual {
+    export function getValue<T>(objects: DataViewObjects, objectName: string, propertyName: string, defaultValue: T ): T {
+        if(objects) {
+            let object = objects[objectName];
+            if(object) {
+                let property: T = <T>object[propertyName];
+                if(property !== undefined) {
+                    return property;
+                }
+            }
+        }
+        return defaultValue;
+    }
+
+    export function getFillValue(objects: DataViewObjects, objectName: string, propertyName: string, defaultValue: string ): string {
+        if(objects) {
+            let object = objects[objectName];
+            if(object) {
+                let fill: Fill = <Fill>object[propertyName];
+                if(fill !== undefined && fill.solid !== undefined && fill.solid.color !== undefined) {
+                    return fill.solid.color;
+                }
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/templates/visuals/rhtml/tsconfig.json
+++ b/templates/visuals/rhtml/tsconfig.json
@@ -10,6 +10,7 @@
   "files": [
     ".api/v1.6.0/PowerBI-visuals.d.ts",
     "src/htmlInjectionUtility.ts",
+    "src/objectEnumerationUtility.ts",
     "node_modules/powerbi-visuals-utils-dataviewutils/lib/index.d.ts",
     "src/settings.ts",
     "src/visual.ts"

--- a/templates/visuals/rvisual/src/objectEnumerationUtility.ts
+++ b/templates/visuals/rvisual/src/objectEnumerationUtility.ts
@@ -1,0 +1,27 @@
+module powerbi.extensibility.visual {
+    export function getValue<T>(objects: DataViewObjects, objectName: string, propertyName: string, defaultValue: T ): T {
+        if(objects) {
+            let object = objects[objectName];
+            if(object) {
+                let property: T = <T>object[propertyName];
+                if(property !== undefined) {
+                    return property;
+                }
+            }
+        }
+        return defaultValue;
+    }
+
+    export function getFillValue(objects: DataViewObjects, objectName: string, propertyName: string, defaultValue: string ): string {
+        if(objects) {
+            let object = objects[objectName];
+            if(object) {
+                let fill: Fill = <Fill>object[propertyName];
+                if(fill !== undefined && fill.solid !== undefined && fill.solid.color !== undefined) {
+                    return fill.solid.color;
+                }
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/templates/visuals/rvisual/tsconfig.json
+++ b/templates/visuals/rvisual/tsconfig.json
@@ -11,6 +11,7 @@
         ".api/v1.6.0/PowerBI-visuals.d.ts",
         "node_modules/powerbi-visuals-utils-dataviewutils/lib/index.d.ts",
         "src/settings.ts",
+        "src/objectEnumerationUtility.ts",
         "src/visual.ts"
     ]
 }


### PR DESCRIPTION
I restored the old version of `objectEnumerationUtility.ts`.
But I do not understand why this is necessary if you can use `parseSettings` method to get full settings object