### PR TITLE
Update Typescript to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "powerbi-visuals-utils-dataviewutils": "1.2.0",
     "serve-static": "^1.10.2",
     "source-map-concat": "^1.0.1",
-    "typescript": "2.1.5",
+    "typescript": "2.4.1",
     "uglify-js": "^2.6.2",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
With the version fixed to an old version of typescript, I cannot use a library that uses some new features such as the `object` type. 