### PR TITLE
Cannot create visuals with dashes

### DIFF
--- a/spec/e2e/pbivizNewSpec.js
+++ b/spec/e2e/pbivizNewSpec.js
@@ -314,6 +314,15 @@ describe("E2E - pbiviz new", () => {
             error = e;
         }
         expect(error.message).toMatch("The visual name cannot be equal to a reserved JavaScript keyword");
+        
+        invalidVisualName = 'foo-bar';
+        try {
+            FileSystem.runPbiviz('new', invalidVisualName);
+        }
+        catch (e) {
+            error = e;
+        }
+        expect(error.message).toMatch("The visual name cannot contain dashes");
 
     });
 


### PR DESCRIPTION
Names with - lead to odd compile errors but the validator doesn't catch it. This patch doesn't actually implement a fix but adds a test for the problem. 