### PR TITLE
Add .tsx watch-state configuration

### DIFF
--- a/lib/VisualBuilder.js
+++ b/lib/VisualBuilder.js
@@ -459,13 +459,13 @@ class VisualBuilder extends EventEmitter {
                 changed: false,
                 building: false,
                 name: 'JSON',
-                handler: () => new Promise((resolve) => resolve())
+                handler: () => Promise.resolve()
             },
             '.r': {
                 changed: false,
                 building: false,
                 name: 'RScript',
-                handler: () => new Promise((resolve) => resolve())
+                handler: () => Promise.resolve()
             },
             'stringResources/*.json': {
                 changed: false,

--- a/lib/VisualBuilder.js
+++ b/lib/VisualBuilder.js
@@ -443,6 +443,12 @@ class VisualBuilder extends EventEmitter {
                 name: 'Typescript',
                 handler: TypescriptCompiler.build
             },
+            '.tsx': {
+                changed: false,
+                building: false,
+                name: 'Typescript',
+                handler: TypescriptCompiler.build
+            },
             '.less': {
                 changed: false,
                 building: false,


### PR DESCRIPTION
The .tsx file extension is necessary when writing code with JSX (e.g. React).