### PR TITLE
Incorrect API version reference

### DIFF
--- a/lib/VisualGenerator.js
+++ b/lib/VisualGenerator.js
@@ -339,6 +339,8 @@ class VisualGenerator {
                 vsCodeSettings['json.schemas'][idx].url = `./.api/v${apiVersion}/schema.pbiviz.json`;
             } else if (item.url.match(/.api\/.+\/schema.capabilities.json$/)) {
                 vsCodeSettings['json.schemas'][idx].url = `./.api/v${apiVersion}/schema.capabilities.json`;
+            }  else if (item.url.match(/.api\/.+\/schema.dependencies.json$/)) {
+                vsCodeSettings['json.schemas'][idx].url = `./.api/v${apiVersion}/schema.dependencies.json`;
             }
         });
         fs.writeJsonSync(vsCodeSettingsPath, vsCodeSettings);


### PR DESCRIPTION
For a newly generated visual the path of the `schema.dependencies.json` is not updated with the correct API version/folder.

Altered replace logic to include `schema.dependencies.json` reference