### PR TITLE
Revert "Correct guid generation"

### DIFF
--- a/lib/VisualGenerator.js
+++ b/lib/VisualGenerator.js
@@ -51,7 +51,7 @@ function generateVisualOptions(visualName, apiVersion) {
     return {
         name: name,
         displayName: visualName,
-        guid: name.replace(/-/g, '') + generateVisualGuid(),
+        guid: name + generateVisualGuid(),
         visualClassName: 'Visual',
         apiVersion: apiVersion
     };

--- a/spec/e2e/pbivizNewSpec.js
+++ b/spec/e2e/pbivizNewSpec.js
@@ -286,24 +286,6 @@ describe("E2E - pbiviz new", () => {
         expect(visualConfig.displayName).toBe(visualDisplayName);
     });
 
-    it("Should replace dash ('-') in visual name in visual guid", () => {
-        let visualDisplayName = 'My-Visual-Name-here';
-        let visualName = 'my-Visual-Name-Here';
-        let guidStart = 'myVisualNameHere';
-        let compareLength = guidStart.length;
-        FileSystem.runPbiviz('new', visualDisplayName);
-
-        let visualPath = path.join(tempPath, visualName);
-        let stat = fs.statSync(visualPath);
-        expect(stat.isDirectory()).toBe(true);
-
-        let visualConfig = fs.readJsonSync(path.join(visualPath, 'pbiviz.json')).visual;
-        expect(visualConfig.name).toBe(visualName);
-        expect(visualConfig.displayName).toBe(visualDisplayName);
-        // First number of characters shoudl be the visualname without '-'
-        expect(visualConfig.guid.substr(0, compareLength)).toBe(guidStart);
-    });
-
     it("Should throw error if the visual name invalid", () => {
         let invalidVisualName = '12test';
         let error;


### PR DESCRIPTION
Reverts Microsoft/PowerBI-visuals-tools#131.
Just noticed this logic has already been implemented inside generateVisualGuid().