### PR TITLE
Add typescript namespace support

### DIFF
--- a/lib/TypescriptCompiler.js
+++ b/lib/TypescriptCompiler.js
@@ -151,7 +151,7 @@ function copyFileWithNamespace(source, target, guid) {
     const MODULE = "module", NAMESPACE = "namespace", 
           REG_EXP_PART = "((.|\\n)*?)\s*{", 
           DEFAULT_NAME = "powerbi.extensibility.visual",
-          ENDING = "$1 {",
+          ENDING = "$1 {";
     
     let fileContents = fs.readFileSync(source).toString();
     

--- a/lib/TypescriptCompiler.js
+++ b/lib/TypescriptCompiler.js
@@ -148,9 +148,21 @@ function createPlugin(visualPackage, pluginName) {
  * @param {string} guid - visual guid to append to namespace 
  */
 function copyFileWithNamespace(source, target, guid) {
+    const MODULE = "module", NAMESPACE = "namespace", 
+          REG_EXP_PART = "((.|\\n)*?)\s*{", 
+          DEFAULT_NAME = "powerbi.extensibility.visual",
+          ENDING = "$1 {",
+    
     let fileContents = fs.readFileSync(source).toString();
-    let re = new RegExp("module powerbi.extensibility.visual((.|\\n)*?)\s*{", "g");
-    let output = fileContents.replace(re, "module powerbi.extensibility.visual." + guid + "$1 {");
+    
+    // Search and replace using module
+    let re = new RegExp(`${MODULE} ${DEFAULT_NAME}${REG_EXP_PART}`, "g");
+    let output = fileContents.replace(re, `${MODULE} ${DEFAULT_NAME}.${guid}${ENDING}`);
+    
+    // Search and replace using namespace
+    re = new RegExp(`${NAMESPACE} ${DEFAULT_NAME}${REG_EXP_PART}`, "g");
+    output = output.replace(re, `${NAMESPACE} ${DEFAULT_NAME}.${guid}${ENDING}`);
+    
     fs.writeFileSync(target, output);
 }
 


### PR DESCRIPTION
This PR adds support for `namespace` keyword in visual's classes.
Also, closes #181 