### PR TITLE
Fix the sourcemap paths

### DIFF
--- a/lib/TypescriptCompiler.js
+++ b/lib/TypescriptCompiler.js
@@ -201,6 +201,9 @@ function concatExternalJS(visualPackage) {
         let visualJsPath = visualPackage.buildPath(config.build.dropFolder, visualJsName);
         let visualJsMapPath = visualJsPath + '.map';
 
+        let visualJsMap = JSON.parse(fs.readFileSync(visualJsMapPath).toString());
+        visualJsMap.sourceRoot = path.posix.relative(config.build.dropFolder, config.build.precompileFolder);
+
         let concatFiles = files.map(file => {
             return {
                 source: file,
@@ -211,7 +214,7 @@ function concatExternalJS(visualPackage) {
         concatFiles.push({
             source: visualJsName,
             code: fs.readFileSync(visualJsPath).toString(),
-            map: fs.readFileSync(visualJsMapPath).toString()
+            map: visualJsMap
         });
 
         let concatResult = concat(concatFiles, {


### PR DESCRIPTION
Fix for #188 

The sourceRoot in the input sourcemap file is "../../src/", corresponding to the original location of the source files. This needs to be updated to the precompile location, which yields the correct path both in the filesystem and in the webserver routing for `pbiviz start`.