### PR TITLE
Added support for forward and backward slash in webpack include regex

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=2374540d-a584-4471-9cc9-f67608983f5f
+

--- a/lib/WebPackWrap.js
+++ b/lib/WebPackWrap.js
@@ -205,7 +205,7 @@ class WebPackGenerator {
 
             this.webpackConfig.module.rules.push({
                 test: /(\.ts)x|\.ts$/,
-                include: /powerbi-visuals-|src|precompile\\visualPlugin.ts/,
+                include: /powerbi-visuals-|src|precompile[\/\\]visualPlugin.ts/,
                 exclude: {
                     test: /core-js/
                 },

--- a/lib/WebPackWrap.js
+++ b/lib/WebPackWrap.js
@@ -205,7 +205,7 @@ class WebPackGenerator {
 
             this.webpackConfig.module.rules.push({
                 test: /(\.ts)x|\.ts$/,
-                include: /powerbi-visuals-|src|precompile[\/\\]visualPlugin.ts/,
+                include: /powerbi-visuals-|src|precompile[/\\]visualPlugin.ts/,
                 exclude: {
                     test: /core-js/
                 },


### PR DESCRIPTION
The new webpack implementation checks for the ``.tmp/precompiled/visualPlugin.ts`` but the regex only catches forward slashes that are windows specific. When we use linux machines or ci servers the ``visualPlugin.ts`` is not getting transpiled to es5 causing browser compatibility issues.



