### PR TITLE
Added association for .resjson files

### DIFF
--- a/templates/visuals/_global/.vscode/settings.json
+++ b/templates/visuals/_global/.vscode/settings.json
@@ -10,6 +10,9 @@
     "files.exclude": {
         ".tmp": true
     },
+    "files.associations": {
+        "*.resjson": "json"
+    },
     "search.exclude": {
         ".tmp": true,
         "typings": true


### PR DESCRIPTION
Ensures if using localisation strings, these files they are treated as .json in VS Code. Resolves #295