### PR TITLE
Certificate creation flow (linux)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,15 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "Debug cert install",
+            "program": "${workspaceFolder}/bin/pbiviz.js",
+            "args": [
+                "--install-cert"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "Launch Program",
             "cwd": "${workspaceRoot}",
             "program": "${workspaceFolder}\\bin\\pbiviz-new.js",

--- a/bin/pbiviz.js
+++ b/bin/pbiviz.js
@@ -27,13 +27,25 @@
 
 "use strict";
 
-let confPath = '../config.json';
-let program = require('commander');
-let npmPackage = require('../package.json');
-let ConsoleWriter = require('../lib/ConsoleWriter');
-let config = require(confPath);
-let args = process.argv;
-let CertificateTools = require("../lib/CertificateTools");
+const program = require('commander');
+
+const args = process.argv;
+const confPath = '../config.json';
+const config = require(confPath);
+const npmPackage = require('../package.json');
+const ConsoleWriter = require('../lib/ConsoleWriter');
+const CertificateTools = require("../lib/CertificateTools");
+
+const onOpenCertFile = async () => {
+    const certPath = await CertificateTools.getCertFile(config, true);
+
+    if (!certPath) {
+        ConsoleWriter.error("Certificate not found. The new certificate will be generated");
+        await CertificateTools.createCertFile(config, true);
+    } else {
+        await CertificateTools.openCertFile(config);
+    }
+};
 
 program
     .version(npmPackage.version)
@@ -52,20 +64,9 @@ if (args.length === 2 || (args.length > 2 && args[2] === 'help')) {
 program.parse(args);
 
 if (program.args.length > 0) {
-    let validCommands = program.commands.map(c => c.name());
+    const validCommands = program.commands.map(c => c.name());
     if (validCommands.indexOf(program.args[0]) === -1) {
         ConsoleWriter.error("Invalid command. Run 'pbiviz help' for usage instructions.");
         process.exit(1);
-    }
-}
-
-async function onOpenCertFile() {
-    let certPath = await CertificateTools.getCertFile(config, true);
-    
-    if (!certPath) {
-        ConsoleWriter.error("Certificate not found. The new certificate will be generated");
-        await CertificateTools.createCertFile(config, true);
-    } else {
-        await CertificateTools.openCertFile(config);
     }
 }

--- a/lib/CertificateTools.js
+++ b/lib/CertificateTools.js
@@ -26,31 +26,54 @@
 
 "use strict";
 
-let confPath = '../config.json';
-let nodeExec = require('child_process').exec;
-let path = require('path');
-let os = require('os');
-let ConsoleWriter = require('../lib/ConsoleWriter');
-let fs = require('fs-extra');
-let config = require(confPath);
+const { exec, spawn } = require('child_process');
+const fs = require('fs-extra');
+const path = require('path');
+const os = require('os');
 
-function exec(command, callback) {
+const confPath = '../config.json';
+const config = require(confPath);
+const ConsoleWriter = require('../lib/ConsoleWriter');
+
+const nodeExec = (command, callback) => {
     if (callback) {
-        return nodeExec(command, callback);
+        return exec(command, callback);
     }
 
     return new Promise((resolve, reject) => {
-        nodeExec(command, (err, stdout, stderr) => {
+        exec(command, (err, stdout, stderr) => {
             if (err) {
                 reject(stderr);
             }
             resolve(stdout);
         });
     });
+};
 
-}
+const generateCert = async (startCmd, keyPath, certPath) => {
+    const createCertCommand = `
+        req -newkey rsa:2048
+        -nodes
+        -keyout ${keyPath}
+        -x509
+        -days 180
+        -out ${certPath}
+        -subj "/CN=localhost"
+    `.replace(/\n/g, '');
+    await nodeExec(`${startCmd} ${createCertCommand}`);
+};
 
-async function createCertFile(config, open) {
+const createCertForNix = async (startCmd, keyPath, certPath, open) => {
+    await removeCertFiles(certPath, keyPath);
+    await generateCert(startCmd, keyPath, certPath);
+    if (await fs.exists(certPath)) {
+        ConsoleWriter.info(`Certificate generated. Location is ${certPath}`);
+        open && await openCertFile(config);
+    }
+};
+
+const createCertFile = async (config, open) => {
+    const PLATFORM = os.platform();
     const subject = "localhost";
     const keyLength = 2048;
     const algorithm = "sha256";
@@ -60,56 +83,26 @@ async function createCertFile(config, open) {
         open = false;
     }
 
-    let certPath = path.join(__dirname, '..', config.server.certificate);
-    let keyPath = path.join(__dirname, '..', config.server.privateKey);
-    let pfxPath = path.join(__dirname, '..', config.server.pfx);
+    const certPath = path.join(__dirname, '..', config.server.certificate);
+    const keyPath = path.join(__dirname, '..', config.server.privateKey);
+    const pfxPath = path.join(__dirname, '..', config.server.pfx);
 
-    let openCmds = {
+    const openCmds = {
         linux: 'openssl',
         darwin: 'openssl',
         win32: 'powershell'
     };
-    let startCmd = openCmds[os.platform()];
+    let startCmd = openCmds[PLATFORM];
 
     if (startCmd) {
         try {
             let createCertCommand = "";
-            switch (os.platform()) {
+            switch (PLATFORM) {
                 case "linux":
-                    await removeCertFiles(certPath, keyPath);
-                    createCertCommand =
-                        `  req -newkey rsa:${keyLength}` +
-                        ` -nodes` +
-                        ` -keyout ${keyPath}` +
-                        ` -x509 ` +
-                        ` -days ${validPeriod} ` +
-                        ` -out ${certPath} ` +
-                        ` -subj "/CN=${subject}"`;
-                    await exec(`${startCmd} ${createCertCommand}`);
-                    if (await fs.exists(certPath)) {
-                        ConsoleWriter.info(`Certificate generated. Location is ${certPath}`);
-                        if (open) {
-                            await openCertFile(config);
-                        }
-                    }
+                    spawn('bash', [path.join(__dirname, 'cicert.sh')], { stdio: 'inherit' });
                     break;
                 case "darwin":
-                    await removeCertFiles(certPath, keyPath);
-                    createCertCommand =
-                        `  req -newkey rsa:${keyLength}` +
-                        ` -nodes` +
-                        ` -keyout ${keyPath}` +
-                        ` -x509 ` +
-                        ` -days ${validPeriod} ` +
-                        ` -out ${certPath} ` +
-                        ` -subj "/CN=${subject}"`;
-                    await exec(`${startCmd} ${createCertCommand}`);
-                    if (await fs.exists(certPath)) {
-                        ConsoleWriter.info(`Certificate generated. Location is ${certPath}`);
-                        if (open) {
-                            await openCertFile(config);
-                        }
-                    }
+                    await createCertForNix(startCmd, keyPath, certPath, open);
                     break;
                 case "win32":
                     let passphrase = "";
@@ -119,15 +112,7 @@ async function createCertFile(config, open) {
                     if ((Number(osVersion[0]) === 6 && Number(osVersion[1]) === 1) || Number(osVersion[0]) < 6) {
                         await removeCertFiles(certPath, keyPath, pfxPath);
                         startCmd = "openssl";
-                        createCertCommand =
-                            `  req -newkey rsa:${keyLength}` +
-                            ` -nodes` +
-                            ` -keyout ${keyPath}` +
-                            ` -x509 ` +
-                            ` -days ${validPeriod} ` +
-                            ` -out ${certPath} ` +
-                            ` -subj "/CN=${subject}"`;
-                        await exec(`${startCmd} ${createCertCommand}`);
+                        await generateCert(startCmd, keyPath, certPath);
                         if (await fs.exists(certPath)) {
                             ConsoleWriter.info(`Certificate generated. Location is ${certPath}`);
                             if (open) {
@@ -153,7 +138,7 @@ async function createCertFile(config, open) {
                             `       -FilePath '${pfxPath}' ` +
                             `       -Password (ConvertTo-SecureString -String '${passphrase}' -Force -AsPlainText)`;
 
-                        await exec(`${startCmd} "${createCertCommand}"`);
+                        await nodeExec(`${startCmd} "${createCertCommand}"`);
                         if (await fs.exists(pfxPath)) {
                             ConsoleWriter.info(`Certificate generated. Location is ${pfxPath}. Passphrase is '${passphrase}'`);
                         }
@@ -180,7 +165,7 @@ async function createCertFile(config, open) {
                             `       -FilePath '${pfxPath}' ` +
                             `       -Password (ConvertTo-SecureString -String '${passphrase}' -Force -AsPlainText)`;
 
-                        await exec(`${startCmd} "${createCertCommand}"`);
+                        await nodeExec(`${startCmd} "${createCertCommand}"`);
                         if (await fs.exists(pfxPath)) {
                             ConsoleWriter.info(`Certificate generated. Location is ${pfxPath}. Passphrase is '${passphrase}'`);
                         }
@@ -205,14 +190,14 @@ async function createCertFile(config, open) {
     } else {
         ConsoleWriter.error('Unknown platform. Please place a custom-generated certificate in:', certPath);
     }
-}
+};
 
-async function getCertFile(config, silent) {
+const getCertFile = async (config, silent) => {
     if (typeof silent === "undefined") {
         silent = false;
     }
-    let cert = path.join(__dirname, '..', config.server.certificate);
-    let pfx = path.join(__dirname, '..', config.server.pfx);
+    const cert = path.join(__dirname, '..', config.server.certificate);
+    const pfx = path.join(__dirname, '..', config.server.pfx);
 
     if (await fs.exists(cert)) {
         return cert;
@@ -230,33 +215,33 @@ async function getCertFile(config, silent) {
         ConsoleWriter.info('Certificate not found. Call `pbiviz --install-cert` command to create the new certificate');
     }
     return null;
-}
+};
 
-async function openCertFile(config) {
-    let certPath = await getCertFile(config);
+const openCertFile = async (config) => {
+    const certPath = await getCertFile(config);
 
     if (!certPath) {
         return null;
     }
 
-    let openCmds = {
+    const openCmds = {
         linux: 'xdg-open',
         darwin: 'open',
         win32: 'powershell start'
     };
-    let startCmd = openCmds[os.platform()];
+    const startCmd = openCmds[os.platform()];
     if (startCmd) {
         try {
-            await exec(`${startCmd} "${certPath}"`);
+            await nodeExec(`${startCmd} "${certPath}"`);
         } catch (e) {
             ConsoleWriter.info('Certificate path:', certPath);
         }
     } else {
         ConsoleWriter.info('Certificate path:', certPath);
     }
-}
+};
 
-async function removeCertFiles(certPath, keyPath, pfxPath) {
+const removeCertFiles = async (certPath, keyPath, pfxPath) => {
     try {
         await fs.unlink(certPath);
     } catch (e) {
@@ -278,13 +263,13 @@ async function removeCertFiles(certPath, keyPath, pfxPath) {
             throw e;
         }
     }
-}
+};
 
-function getGlobalPbivizCerts() {
+const getGlobalPbivizCerts = () => {
     return new Promise((resolve) => {
-        exec("npm ls -g powerbi-visuals-tools",
-            function (err, stdout) {
-                let options = {
+        nodeExec("npm ls -g powerbi-visuals-tools",
+            (err, stdout) => {
+                const options = {
                     key: "",
                     cert: "",
                     pfx: "",
@@ -298,10 +283,10 @@ function getGlobalPbivizCerts() {
                 try {
                     const location = stdout.split("\n`-- ")[0];
 
-                    let certPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.certificate);
-                    let keyPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.privateKey);
-                    let pfxPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.pfx);
-                    let globalPbiviConfig = path.join(location, "node_modules", "powerbi-visuals-tools", "config.json");
+                    const certPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.certificate);
+                    const keyPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.privateKey);
+                    const pfxPath = path.join(location, "node_modules", "powerbi-visuals-tools", config.server.pfx);
+                    const globalPbiviConfig = path.join(location, "node_modules", "powerbi-visuals-tools", "config.json");
 
                     options.cert = fs.existsSync(certPath) && certPath;
                     options.key = fs.existsSync(keyPath) && keyPath;
@@ -314,10 +299,10 @@ function getGlobalPbivizCerts() {
                 resolve(options);
             });
     });
-}
+};
 
-async function resolveCertificate() {
-    let options = {};
+const resolveCertificate = async () => {
+    const options = {};
     if (config.server.passphrase) {
         options.passphrase = config.server.passphrase;
     }
@@ -376,7 +361,7 @@ async function resolveCertificate() {
         }
     }
     return options;
-}
+};
 
 module.exports = {
     getCertFile,

--- a/lib/cicert.sh
+++ b/lib/cicert.sh
@@ -1,0 +1,36 @@
+OPENSSL=`which openssl`
+CERTUTIL=`which certutil`
+
+[ $OPENSSL ] && [ $CERTUTIL ] && echo "openssl and certutil found!"
+[ ! $OPENSSL ] || [ ! $CERTUTIL ] && echo "Error: openssl and certutil not found, please install openssl and libnss3 tools first" && exit 404
+
+PBICV='PowerBI Custom Visuals'
+
+ROOT_CA_CRT=root-ca.crt
+ROOT_CA_KEY=root-ca.key
+ROOT_CA_PEM=root-ca.pem
+
+LH_CSR=PowerBICustomVisualTest.csr
+LH_CRT=PowerBICustomVisualTest_public.crt
+LH_KEY=PowerBICustomVisualTest_private.key
+
+# generate root certificate authority
+openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout $PWD/certs/$ROOT_CA_KEY -out $PWD/certs/$ROOT_CA_PEM -subj "/C=US/CN=$PBICV Test CA/O=$PBICV"
+openssl x509 -outform pem -in $PWD/certs/$ROOT_CA_PEM -out $PWD/certs/$ROOT_CA_CRT
+
+# generate certificate for localhost using the generated CA and openssl.cnf
+openssl req -new -nodes -newkey rsa:2048 -keyout $PWD/certs/$LH_KEY -out $PWD/certs/$LH_CSR -subj "/C=US/O=$PBICV/CN=localhost"
+openssl x509 -req -sha256 -days 1024 -in $PWD/certs/$LH_CSR -CA $PWD/certs/$ROOT_CA_PEM -CAkey $PWD/certs/$ROOT_CA_KEY -CAcreateserial -extfile $PWD/lib/openssl.cnf -out $PWD/certs/$LH_CRT
+
+# Add certs to chromium/firefox/system-wide
+certutil -A -n "$PBICV Test CA" -t "CT,C,C" -i $PWD/certs/$ROOT_CA_PEM -d sql:$HOME/.pki/nssdb
+
+for certDB in $(find $HOME/.mozilla* -name "cert*.db")
+do
+certDir=$(dirname ${certDB});
+certutil -A -n "$PBICV Test CA" -t "CT,C,C" -i $PWD/certs/$ROOT_CA_PEM -d sql:${certDir}
+done
+
+echo "\n\e[1m\e[92m ✓ Certificates was generated successfully. Please follow the additional steps to finish:\e[0m"
+echo "run \e[1msudo cp $PWD/certs/$ROOT_CA_PEM /usr/local/share/ca-certificates/powerbi-root-ca.crt\e[0m"
+echo "then run \e[1msudo update-ca-certificates\e[0m"

--- a/lib/openssl.cnf
+++ b/lib/openssl.cnf
@@ -1,0 +1,7 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1=localhost

--- a/spec/e2e/pbivizCertSpec.js
+++ b/spec/e2e/pbivizCertSpec.js
@@ -26,12 +26,12 @@
 
 "use strict";
 
-let fs = require('fs-extra');
-let path = require('path');
-console.log(__dirname);
-let config = require('./../../config.json');
+const fs = require('fs-extra');
+const path = require('path');
 
-let CertificateTools = require('./../../lib/CertificateTools');
+const config = require('./../../config.json');
+
+const CertificateTools = require('./../../lib/CertificateTools');
 
 describe("E2E - pbiviz --install-cert", () => {
     beforeEach((done) => {
@@ -40,14 +40,14 @@ describe("E2E - pbiviz --install-cert", () => {
 
     describe("pbiviz", () => {
         it("pbiviz --install-cert command should generate certificate", (done) => {
-            let certPath = path.join(__dirname, "../../", config.server.certificate);
-            let keyPath = path.join(__dirname, "../../", config.server.privateKey);
-            let pfxPath = path.join(__dirname, "../../", config.server.pfx);
-            let certExists = fs.existsSync(certPath);
-            let keyExists = fs.existsSync(keyPath);
-            let pfxExists = fs.existsSync(pfxPath);
+            const certPath = path.join(__dirname, "../../", config.server.certificate);
+            const keyPath = path.join(__dirname, "../../", config.server.privateKey);
+            const pfxPath = path.join(__dirname, "../../", config.server.pfx);
+            const certExists = fs.existsSync(certPath);
+            const keyExists = fs.existsSync(keyPath);
+            const pfxExists = fs.existsSync(pfxPath);
 
-            let result = (certExists && keyExists) || pfxExists;
+            const result = (certExists && keyExists) || pfxExists;
 
             expect(result).toBeTruthy();
             done();


### PR DESCRIPTION
# Issue

Neither Chrome not Firefox couldn't accept the self-signed cert generated by our tool.
![not_secure](https://user-images.githubusercontent.com/3394441/77723021-5107d480-7000-11ea-9ca9-fc52d93bd09a.png)
![not_secure_ff](https://user-images.githubusercontent.com/3394441/77723023-51a06b00-7000-11ea-866d-b5d7ed7cc9fe.png)


# Solution

Extend the cert creation process by adding a trusted root authority for localhost

# Result

Both FF&Chrome now trust the cert

![secure_chrome](https://user-images.githubusercontent.com/3394441/77729882-c1b6ed00-7010-11ea-9327-332e303f89fa.png)
![secure_ff](https://user-images.githubusercontent.com/3394441/77729886-c2e81a00-7010-11ea-9355-83acf6bb5f13.png)
