### PR TITLE
fix the regex of the plotly js file

### DIFF
--- a/templates/visuals/rhtml/r_files/flatten_HTML.r
+++ b/templates/visuals/rhtml/r_files/flatten_HTML.r
@@ -97,7 +97,7 @@ FindSrcReplacement <- function(str)
   # finds reference to 'plotly' js and replaces with a version from CDN
   # This allows the HTML to be smaller, since this script is not fully embedded in it
   str <- iconv(str, to="UTF-8")
-  pattern = "plotlyjs-(\\w.+)/plotly-latest.min.js"
+  pattern = "plotly-(\\w.+)/plotly-latest.min.js"
   match1=regexpr(pattern, str)
   attr(match1, 'useBytes') <- FALSE
   strMatch=regmatches(str, match1, invert = FALSE)


### PR DESCRIPTION
The function FindSrcReplacement() is to find reference to 'plotly' js and replaces with a version from CDN, this allows the HTML to be smaller, since this script is not fully embedded in it.
It's supposed to be displayed as below picture in the output html file.
![image](https://user-images.githubusercontent.com/7992815/108444384-620c9600-720f-11eb-8d51-c38bc912dfde.png)
But with the current regex "plotlyjs-(\\w.+)/plotly-latest.min.js", it couldn't find the reference, the whole 'plotly' js would be embedded into the output html file, which increases 3.2MB to the output size.
![image](https://user-images.githubusercontent.com/7992815/108444846-3a69fd80-7210-11eb-8886-963a24100b72.png)

This issue caused the output file size exceeds the current PowerBI R visual output file size limitation.