### PR TITLE
Updated dependency to powerbi-visuals-webpack-plugin 2.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
 
+## 3.2.4
+* Updated dependency to powerbi-visuals-webpack-plugin
 
 ## 3.2.2
 * Removed npm-force-resolutions package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5485,9 +5485,9 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "powerbi-visuals-webpack-plugin": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/powerbi-visuals-webpack-plugin/-/powerbi-visuals-webpack-plugin-2.2.6.tgz",
-      "integrity": "sha512-qbf7BBXtnHb6UndROwxuK5q1hbgJupmE0Z7x2leX5GqDB3KCnCoVSKf0kFRw/sGU3qB81xkoCn6sv1e1nf3r+w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/powerbi-visuals-webpack-plugin/-/powerbi-visuals-webpack-plugin-2.3.0.tgz",
+      "integrity": "sha512-fUsJVZx4vdUI+YDKUzIQl4LlBU1Nvi86jnaKto5Pa/QR/4qH6jhncJU+CZkv/enNPuUCDJKXG1KOq3OSjtVDVQ==",
       "requires": {
         "ajv": "6.12.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./lib/VisualPackage.js",
   "scripts": {
@@ -61,7 +61,7 @@
     "mini-css-extract-plugin": "^1.4.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
-    "powerbi-visuals-webpack-plugin": "2.2.6",
+    "powerbi-visuals-webpack-plugin": "^2.3.0",
     "process": "^0.11.10",
     "punycode": "^2.1.1",
     "querystring-es3": "^0.2.1",


### PR DESCRIPTION
 Updated dependency to powerbi-visuals-webpack-plugin 2.3.0, needed for CV modal dialog support.