### PR TITLE
Update Typescript to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7083,9 +7083,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "timers-browserify": "^2.0.12",
     "ts-loader": "6.2.2",
     "tty-browserify": "0.0.1",
-    "typescript": "3.8.3",
+    "typescript": "4.3.5",
     "url": "^0.11.0",
     "util": "^0.12.3",
     "uuid": "7.0.2",


### PR DESCRIPTION
The used typescript version is more than a year old at this point. This prevents compilation with libraries that use newer language features in their type definition files.