### PR TITLE
Added guid flag for custom builds

### DIFF
--- a/bin/pbiviz.js
+++ b/bin/pbiviz.js
@@ -67,7 +67,7 @@ pbiviz
     .action(() => {
         CommandManager.installCert();
     });
-
+ 
 pbiviz
     .command('start')
     .usage('[options]')

--- a/spec/e2e/pbivizPackageSpec.js
+++ b/spec/e2e/pbivizPackageSpec.js
@@ -278,36 +278,36 @@ describe("E2E - pbiviz package", () => {
 
     it("Should correctly generate pbiviz file with stringResources localization", (done) => {
         const resourceStringLocalization =
-        {
-            "locale": "ru-RU",
-            "values": {
-                "formattingGeneral": "Общие настройки",
-                "formattingGeneralOrientation": "Ориентация",
-                "formattingGeneralOrientationVertical": "Вертикальная"
-            }
-        };
+            {
+                "locale": "ru-RU",
+                "values": {
+                    "formattingGeneral": "Общие настройки",
+                    "formattingGeneralOrientation": "Ориентация",
+                    "formattingGeneralOrientationVertical": "Вертикальная"
+                }
+            };
         const validStringResources =
-        {
-            "ru-RU": {
-                "formattingGeneral": "Общие настройки",
-                "formattingGeneralOrientation": "Ориентация",
-                "formattingGeneralOrientationVertical": "Вертикальная"
-            }
-        };
+            {
+                "ru-RU": {
+                    "formattingGeneral": "Общие настройки",
+                    "formattingGeneralOrientation": "Ориентация",
+                    "formattingGeneralOrientationVertical": "Вертикальная"
+                }
+            };
 
         mkDirPromise('stringResources')
             .then(() => writeJsonPromise('stringResources/ru-RU.json', resourceStringLocalization))
-            .then(() =>
+            .then(() => 
                 readJsonPromise('pbiviz.json')
             )
             .then((pbivizJson) => {
                 pbivizJson.stringResources = ["stringResources/ru-RU.json"];
                 return writeJsonPromise('pbiviz.json', pbivizJson);
             })
-            .then(() =>
+            .then(() => 
                 FileSystem.runPbiviz('package', undefined, '--no-pbiviz --no-minify --resources')
             )
-            .then(() =>
+            .then(() => 
                 readJsonPromise(path.join(visualPath, 'dist', 'resources', visualPbiviz.visual.guid + '.pbiviz.json'))
             )
             .then((pbivizJson) => {
@@ -322,31 +322,31 @@ describe("E2E - pbiviz package", () => {
 
     it("Should correctly generate pbiviz file with RESJSON localization", (done) => {
         const ResJsonEngLocalization =
-        {
-            "formattingGeneral": "General",
-            "formattingGeneralOrientation": "Orientation",
-            "formattingGeneralOrientationVertical": "Vertical"
-        };
-        const ResJsonRuLocalization =
-        {
-            "formattingGeneral": "Общие настройки",
-            "formattingGeneralOrientation": "Ориентация",
-            "formattingGeneralOrientationVertical": "Вертикальная"
-        };
-
-        const validStringResources =
-        {
-            "en-US": {
+            {
                 "formattingGeneral": "General",
                 "formattingGeneralOrientation": "Orientation",
                 "formattingGeneralOrientationVertical": "Vertical"
-            },
-            "ru-RU": {
+            };
+        const ResJsonRuLocalization =
+            {
                 "formattingGeneral": "Общие настройки",
                 "formattingGeneralOrientation": "Ориентация",
                 "formattingGeneralOrientationVertical": "Вертикальная"
-            }
-        };
+            };
+
+        const validStringResources =
+            {
+                "en-US": {
+                    "formattingGeneral": "General",
+                    "formattingGeneralOrientation": "Orientation",
+                    "formattingGeneralOrientationVertical": "Vertical"
+                },
+                "ru-RU": {
+                    "formattingGeneral": "Общие настройки",
+                    "formattingGeneralOrientation": "Ориентация",
+                    "formattingGeneralOrientationVertical": "Вертикальная"
+                }
+            };
         mkDirPromise('stringResources')
             .then(() =>
                 Promise.all([
@@ -355,10 +355,10 @@ describe("E2E - pbiviz package", () => {
                     mkDirPromise('stringResources/ru-RU')
                         .then(() => writeJsonPromise('stringResources/ru-RU/resources.resjson', ResJsonRuLocalization))
                 ]))
-            .then(() =>
+            .then(() => 
                 FileSystem.runPbiviz('package', undefined, '--no-pbiviz --no-minify --resources')
             )
-            .then(() =>
+            .then(() => 
                 readJsonPromise(path.join(visualPath, 'dist', 'resources', visualPbiviz.visual.guid + '.pbiviz.json'))
             )
             .then((pbivizJson) => {
@@ -373,44 +373,44 @@ describe("E2E - pbiviz package", () => {
 
     it("Should correctly generate pbiviz file with RESJSON and stringResources localizations", (done) => {
         const resourceStringRuLocalization =
-        {
-            "locale": "ru-RU",
-            "values": {
-                "formattingGeneral": "Главные настройки",
-                "formattingGeneralOrientation": "Ориентация",
-                "formattingHeaderFontColor": "Цвет шрифта",
-                "formattingHeaderBackground": "Цвет фона"
-            }
-        };
+            {
+                "locale": "ru-RU",
+                "values": {
+                    "formattingGeneral": "Главные настройки",
+                    "formattingGeneralOrientation": "Ориентация",
+                    "formattingHeaderFontColor": "Цвет шрифта",
+                    "formattingHeaderBackground": "Цвет фона"
+                }
+            };
 
         const ResJsonEngLocalization =
-        {
-            "formattingGeneral": "General",
-            "formattingGeneralOrientation": "Orientation",
-            "formattingGeneralOrientationVertical": "Vertical"
-        };
-        const ResJsonRuLocalization =
-        {
-            "formattingGeneral": "Общие настройки",
-            "formattingGeneralOrientation": "Ориентация",
-            "formattingGeneralOrientationVertical": "Вертикальная"
-        };
-
-        const validStringResources =
-        {
-            "en-US": {
+            {
                 "formattingGeneral": "General",
                 "formattingGeneralOrientation": "Orientation",
                 "formattingGeneralOrientationVertical": "Vertical"
-            },
-            "ru-RU": {
+            };
+        const ResJsonRuLocalization =
+            {
                 "formattingGeneral": "Общие настройки",
                 "formattingGeneralOrientation": "Ориентация",
-                "formattingHeaderFontColor": "Цвет шрифта",
-                "formattingHeaderBackground": "Цвет фона",
                 "formattingGeneralOrientationVertical": "Вертикальная"
-            }
-        };
+            };
+
+        const validStringResources =
+            {
+                "en-US": {
+                    "formattingGeneral": "General",
+                    "formattingGeneralOrientation": "Orientation",
+                    "formattingGeneralOrientationVertical": "Vertical"
+                },
+                "ru-RU": {
+                    "formattingGeneral": "Общие настройки",
+                    "formattingGeneralOrientation": "Ориентация",
+                    "formattingHeaderFontColor": "Цвет шрифта",
+                    "formattingHeaderBackground": "Цвет фона",
+                    "formattingGeneralOrientationVertical": "Вертикальная"
+                }
+            };
 
         mkDirPromise('stringResources')
             .then(() =>
@@ -426,7 +426,7 @@ describe("E2E - pbiviz package", () => {
                 pbivizJson.stringResources = ["stringResources/ru-RU.json"];
                 return writeJsonPromise('pbiviz.json', pbivizJson);
             })
-            .then(() =>
+            .then(() => 
                 FileSystem.runPbiviz('package', undefined, '--no-pbiviz --no-minify --resources')
             )
             .then(() => readJsonPromise(path.join(visualPath, 'dist', 'resources', visualPbiviz.visual.guid + '.pbiviz.json')))
@@ -443,7 +443,7 @@ describe("E2E - pbiviz package", () => {
     it("Should generate statistic files without flags", () => {
         FileSystem.runPbiviz('package');
         const statisticFilePath = path.join(visualPath, 'webpack.statistics.prod.html');
-        try {
+        try { 
             expect(fs.statSync(statisticFilePath).isFile()).toBe(true);
         } catch (error) {
             expect(error).toBeNull();
@@ -453,7 +453,7 @@ describe("E2E - pbiviz package", () => {
     it("Shouldn't generate statistic files with --no-stats flag", () => {
         FileSystem.runPbiviz('package', '--no-stats');
         const statisticFilePath = path.join(visualPath, 'webpack.statistics.prod.html');
-        try {
+        try { 
             expect(fs.statSync(statisticFilePath).isFile()).toBe(false);
         } catch (error) {
             expect(error).not.toBeNull();

--- a/src/CommandManager.ts
+++ b/src/CommandManager.ts
@@ -56,7 +56,7 @@ export default class CommandManager {
             ConsoleWriter.error('Nothing to build. Cannot use --no-pbiviz without --resources');
             process.exit(1);
         }
-         
+
         const webpackOptions: WebpackOptions = {
             devMode: false,
             generateResources: options.resources,

--- a/src/WebPackWrap.ts
+++ b/src/WebPackWrap.ts
@@ -123,7 +123,7 @@ export default class WebPackWrap {
         this.webpackConfig.watchOptions.ignored.push(visualPluginPath)
         if (tsconfig.compilerOptions.out) {
             this.webpackConfig.entry = {
-                "visual.js": visualJSFilePath 
+                "visual.js": visualJSFilePath
             };
         } else {
             this.webpackConfig.entry["visual.js"] = [visualPluginPath];


### PR DESCRIPTION
## Description
Implemented flag for pbiviz package command to specify custom guid without changing pbiviz json. I  also implemented one test to make sure that the value is changing. However, there might be a problem if the developer enters a numeric value since this value is used as the name of the variable in visualPlugin.ts. What do we want to do in this case? Maybe to use some default value instead or just to throw an error? 

## Why I did this
Right now running pbiviz package command builds the visual using guid value from pbiviz.json file. It causes problems with testing packages.

Appreciate any feedback😊