### PR TITLE
disabled node runtime fallback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
 
+## 5.4.2
+* Added the **node: false** option to the webpack plugin to eliminate the use of the potentially dangerous **new Function()** method, which ensures compatibility with the Node.js runtime.
+* Introduced support for *.mjs ECMAScript modules.
+
 ## 5.4.1
 * Updated R-based visuals settings.ts file to work properly with the new API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-tools",
-      "version": "5.4.1",
+      "version": "5.4.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./bin/pbiviz.js",
   "type": "module",

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -13,6 +13,7 @@ const webpackConfig = {
         'visual.js': ['./src/visual.ts']
     },
     target: 'web',
+    node: false,
     devtool: false,
     mode: "production",
     optimization: {
@@ -74,7 +75,7 @@ const webpackConfig = {
         "powerbi-visuals-api": 'null'
     },
     resolve: {
-        extensions: ['.tsx', '.ts', '.jsx', '.js', '.css'],
+        extensions: ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.css'],
         modules: ['node_modules', path.resolve(rootPath, 'node_modules')],
         fallback: {
             assert: "assert",


### PR DESCRIPTION
* Added the **node: false** option to the webpack plugin to eliminate the use of the potentially dangerous **new Function()** method, which ensures compatibility with the Node.js runtime.
* Introduced support for *.mjs ECMAScript modules.