### PR TITLE
Update webpack.config.ts

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -75,6 +75,7 @@ const webpackConfig = {
         "powerbi-visuals-api": 'null'
     },
     resolve: {
+        symlinks: false,
         extensions: ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.css'],
         modules: ['node_modules', path.resolve(rootPath, 'node_modules')],
         fallback: {


### PR DESCRIPTION
Whether to resolve symlinks to their symlinked location.

When enabled, symlinked resources are resolved to their real path, not their symlinked location. Note that this may cause module resolution to fail when using tools that symlink packages (like npm link).

https://webpack.js.org/configuration/resolve/#resolvesymlinks