### PR TITLE
Fix: make config-parsing functions more robust

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,11 +31,30 @@ export function getJsPath(filePath: string) {
 }
 
 async function safelyImport(filePath: string) {
-    return fs.existsSync(filePath) && (await import(`file://${filePath}`)).default;
+    if (!fs.existsSync(filePath)) {
+        return null;
+    }
+
+    try {
+        return (await import(`file://${filePath}`)).default;
+    } catch (e) {
+        console.error(`Error importing JS config from ${filePath}`, e);
+        return null;
+    }
 }
 
 function safelyParse(filePath: string) {
-    return fs.existsSync(filePath) && JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    if (!fs.existsSync(filePath)) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    }
+    catch (e) {
+        console.error(`Error parsing JSON config from ${filePath}`, e);
+        return null;
+    }
 }
 
 export async function readJsonFromRoot(jsonFilename: string) {


### PR DESCRIPTION
## Summary
This PR makes the configuration parsing functions introduced in #534 more robust.

## Context
Specifically, the current implementation allows improperly formatted JS/JSON configuration files to break the `safelyImport` and `safelyParse` functions. This isn't a concern if those functions are called with their appropriate file types (`.js` and `.json` respectively), but **accidentally mixing up those file types (or supplying incorrectly formatted files to those functions) will result in thrown exceptions!**

In order for these functions to live up to their "safe" name, they arguably shouldn't be throwing exceptions. Rather, they should fail gracefully and notify the end-user (or `pbiviz` developer) through console warnings.

## Caveat
I've tested this change with the `pbiviz` tests and confirmed they all pass.

I have **not** tested to see what happens if both `safelyImport` and `safelyParse` fail in a given `readJsonFrom*` call. (The `readJsonFrom*` call would return `null` after warning that both `safelyImport` and `safelyParse` had failed, which I assume would cause an exception further down the execution path.)
