### PR TITLE
 Add validation for leading zeros in visual version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Change Log - PowerBI Visual Tools (pbiviz)
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
-## 7.1.2
+## 7.2.0
 * Added a pre-build validation that fails with an error when the visual version contains parts with leading zeros (rejected by the Power BI marketplace package acceptance check).
 
 ## 7.1.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
 
+## 7.1.2
+* Added a pre-build validation that warns when the visual version contains parts with leading zeros (rejected by the Power BI marketplace package acceptance check).
+
 ## 7.1.1
 * Minor documentation and metadata updates.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 This page contains information about changes to the PowerBI Visual Tools (pbiviz).
 ## 7.1.2
-* Added a pre-build validation that warns when the visual version contains parts with leading zeros (rejected by the Power BI marketplace package acceptance check).
+* Added a pre-build validation that fails with an error when the visual version contains parts with leading zeros (rejected by the Power BI marketplace package acceptance check).
 
 ## 7.1.2
 * Npm audit fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "7.1.2",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-tools",
-      "version": "7.1.2",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-tools",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "7.1.2",
+  "version": "7.2.0",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./bin/pbiviz.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-tools",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Command line tool for creating and publishing visuals for Power BI",
   "main": "./bin/pbiviz.js",
   "type": "module",

--- a/spec/unit/FeatureManagerSpec.js
+++ b/spec/unit/FeatureManagerSpec.js
@@ -36,7 +36,7 @@ const config = await readJsonFromRoot('config.json');
 
 describe("Features", () => {
     describe("Visual", () => {
-        const { APIVersion, VisualVersion, AuthorInfo } = features;
+        const { APIVersion, VisualVersion, VisualVersionLeadingZeros, AuthorInfo } = features;
         it("Should support API Version", () => {
             const Visual = {
                 doesAPIVersionMatch: (minVersion) =>  {
@@ -56,6 +56,48 @@ describe("Features", () => {
                 }
             }
             expect(VisualVersion.isSupported(Visual)).toBeTrue;
+        });
+
+        describe("VisualVersionLeadingZeros", () => {
+            it("Should support when version has no leading zeros", () => {
+                const capabilities = {};
+                const visualConfig = {
+                    visual: { version: "1.16.345.1" },
+                    apiVersion: "5.3.0"
+                };
+                const visual = new Visual(capabilities, visualConfig);
+                expect(VisualVersionLeadingZeros.isSupported(visual)).toBeTrue();
+            });
+
+            it("Should support when version parts are single zeros", () => {
+                const capabilities = {};
+                const visualConfig = {
+                    visual: { version: "1.0.0.0" },
+                    apiVersion: "5.3.0"
+                };
+                const visual = new Visual(capabilities, visualConfig);
+                expect(VisualVersionLeadingZeros.isSupported(visual)).toBeTrue();
+            });
+
+            it("Should not support when a version part has a leading zero", () => {
+                const capabilities = {};
+                const visualConfig = {
+                    visual: { version: "1.16.0345.1" },
+                    apiVersion: "5.3.0"
+                };
+                const visual = new Visual(capabilities, visualConfig);
+                expect(VisualVersionLeadingZeros.isSupported(visual)).toBeFalse();
+            });
+
+            it("Should not support when multiple version parts have leading zeros", () => {
+                const capabilities = {};
+                const visualConfig = {
+                    visual: { version: "01.02.03.04" },
+                    apiVersion: "5.3.0"
+                };
+                const visual = new Visual(capabilities, visualConfig);
+                expect(VisualVersionLeadingZeros.isSupported(visual)).toBeFalse();
+            });
         });
 
         describe("AuthorInfo", () => {

--- a/src/Visual.ts
+++ b/src/Visual.ts
@@ -22,6 +22,10 @@ export class Visual {
         return this.visualVersion.split(".").length === length
     }
 
+    public hasVisualVersionLeadingZeros() {
+        return this.visualVersion.split(".").some(part => /^0\d+/.test(part));
+    }
+
     public isAuthorDefined() {
         const author = this.config?.author;
         const emailRegex = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;

--- a/src/features/VisualVersionLeadingZeros.ts
+++ b/src/features/VisualVersionLeadingZeros.ts
@@ -1,0 +1,16 @@
+import { Visual } from "../Visual.js";
+import BaseFeature from "./BaseFeature.js";
+import { Severity, Stage, VisualFeatureType } from "./FeatureTypes.js";
+
+export default class VisualVersionLeadingZeros implements BaseFeature {
+    public static featureName = "Visual version leading zeros"
+    public static errorMessage = `${this.featureName} - version parts must not contain leading zeros (e.g. use 1.16.345.1 instead of 1.16.0345.1). Update the pbiviz.json file. Versions with leading zeros are rejected by the Power BI marketplace package acceptance check.`
+    public static severity = Severity.Warning
+    public static stage = Stage.PreBuild
+    public static visualFeatureType = VisualFeatureType.All
+    public static certificationRequired = true
+
+    static isSupported(visual: Visual) {
+        return !visual.hasVisualVersionLeadingZeros()
+    }
+}

--- a/src/features/VisualVersionLeadingZeros.ts
+++ b/src/features/VisualVersionLeadingZeros.ts
@@ -4,8 +4,8 @@ import { Severity, Stage, VisualFeatureType } from "./FeatureTypes.js";
 
 export default class VisualVersionLeadingZeros implements BaseFeature {
     public static featureName = "Visual version leading zeros"
-    public static errorMessage = `${this.featureName} - version parts must not contain leading zeros (e.g. use 1.16.345.1 instead of 1.16.0345.1). Update the pbiviz.json file. Versions with leading zeros are rejected by the Power BI marketplace package acceptance check.`
-    public static severity = Severity.Warning
+    public static errorMessage = `${this.featureName} - version parts must not contain leading zeros (e.g. use 1.2.3.4 instead of 1.2.03.4). Update the pbiviz.json file. Versions with leading zeros are rejected by the Power BI marketplace package acceptance check.`
+    public static severity = Severity.Error
     public static stage = Stage.PreBuild
     public static visualFeatureType = VisualFeatureType.All
     public static certificationRequired = true

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -26,6 +26,7 @@ import TotalSubTotal from './TotalSubTotal.js'
 import WarningIcon from './WarningIcon.js'
 import APIVersion from './APIVersion.js'
 import VisualVersion from './VisualVersion.js'
+import VisualVersionLeadingZeros from './VisualVersionLeadingZeros.js'
 
 export { 
     AdvancedEditMode, AllowInteractions, AnalyticsPane, Bookmarks, 
@@ -34,5 +35,5 @@ export {
     HighlightData, KeyboardNavigation, LandingPage, LaunchURL,
     Localizations, LocalStorage, ModalDialog, RenderingEvents,
     SelectionAcrossVisuals, SyncSlicer, Tooltips, TotalSubTotal,
-    WarningIcon, APIVersion, VisualVersion, AuthorInfo
+    WarningIcon, APIVersion, VisualVersion, VisualVersionLeadingZeros, AuthorInfo
 }


### PR DESCRIPTION
**Description:**

* Adds a pre-build check that flags visual versions containing leading zeros, which are rejected by the Power BI marketplace package acceptance check.

**Changes**

* New feature VisualVersionLeadingZeros (src/features/VisualVersionLeadingZeros.ts) - a [PreBuild], [Warning]-severity, certification-relevant check that fails when any version part has a leading zero (e.g. 1.16.0345.1), with guidance to use 1.16.345.1 and update [pbiviz.json].
* src/Visual.ts - adds hasVisualVersionLeadingZeros().
* src/features/index.ts - registers the new feature.
* [spec/unit/FeatureManagerSpec.js] - unit tests covering versions with/without leading zeros.

**Notes**

* Warning-level only; does not block builds, surfaces the issue early before marketplace submission.
* Single commit: Add check for leading zeros in version.